### PR TITLE
switch from always_run to check_mode

### DIFF
--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -17,7 +17,7 @@
 - name: systemd-escape systemd_mount_mountpoint
   command: "systemd-escape -p --suffix=mount '{{ systemd_mount_mountpoint }}'"
   register: systemd_escape_mount_mountpoint
-  always_run: true
+  check_mode: no
 
 - name: Set mount conf
   become: yes


### PR DESCRIPTION
Since Ansible 2.6 always_run is deprecated [1] and replaced by
check_mode: no. (available since 2.2)