### PR TITLE
mount: Add systemd_mount_started parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ systemd_timer_service_enabled: True
 # systemd_mount_mountpoint
 systemd_mount_type: ext4
 # systemd_mount_options
+systemd_mount_started: false
 
 #systemd_timer_OnCalendar: *-*-* 00/2:00:00
 #systemd_timer_RemainAfterElapse: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,9 @@
 - name: Reload systemd
   become: yes
   command: systemctl daemon-reload
+
+- name: Start mount
+  service:
+    name: "{{ systemd_escape_mount_mountpoint.stdout }}"
+    state: started
+  when: systemd_mount_started

--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -24,3 +24,9 @@
   template: src=mount.mount.j2 dest="{{systemd_mount_dir}}/{{ systemd_escape_mount_mountpoint.stdout }}"
   notify:
     - Reload systemd
+    - Start mount
+
+- name: Ensure the service is started
+  meta: flush_handlers
+  when: systemd_mount_started
+


### PR DESCRIPTION
This new parameter a allow a user to force a start of the mount after the run of systemd role.
This is mostly useful for roles dependencies, if you need a mount to be mounted before
running the next ansible role.